### PR TITLE
Update cubbit.rb

### DIFF
--- a/Casks/cubbit.rb
+++ b/Casks/cubbit.rb
@@ -1,6 +1,6 @@
 cask "cubbit" do
   version "9.2.6"
-  sha5356 "ea5fad7d95530bb08c062dec44bb8c710067f90f090970526d07aa525bdb33cf"
+  sha256 "ea5fad7d95530bb08c062dec44bb8c710067f90f090970526d07aa525bdb33cf"
 
   url "https://get.cubbit.io/desktop/mac/Cubbit-#{version}.dmg"
   name "Cubbit"

--- a/Casks/cubbit.rb
+++ b/Casks/cubbit.rb
@@ -1,6 +1,6 @@
 cask "cubbit" do
-  version "9.1.4"
-  sha256 "e93feb1290dfde0350ede3f388cddfd2aeee2321eb7d980e959dc5887bd8add3"
+  version "9.2.6"
+  sha512 "rwz7M77f0Zj4/mTMFMO/AsrinshnauUqE7nRNAKR4jdQ1UD7FUrJwaHCirnSbJJ/Q1OqFJHKy6QkWY4WoXzmxw=="
 
   url "https://get.cubbit.io/desktop/mac/Cubbit-#{version}.dmg"
   name "Cubbit"

--- a/Casks/cubbit.rb
+++ b/Casks/cubbit.rb
@@ -1,6 +1,6 @@
 cask "cubbit" do
   version "9.2.6"
-  sha512 "rwz7M77f0Zj4/mTMFMO/AsrinshnauUqE7nRNAKR4jdQ1UD7FUrJwaHCirnSbJJ/Q1OqFJHKy6QkWY4WoXzmxw=="
+  sha5356 "ea5fad7d95530bb08c062dec44bb8c710067f90f090970526d07aa525bdb33cf"
 
   url "https://get.cubbit.io/desktop/mac/Cubbit-#{version}.dmg"
   name "Cubbit"


### PR DESCRIPTION
### Description
The pr updates the app version and the related ~sha using the [data generated from electron](get.cubbit.io/desktop/mac/latest-mac.yml) during the release process~.

> sha512 is not supported by brew
sha 256 generated using `sha256sum`

